### PR TITLE
[WAC-89] 지역 상세 페이지 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ group = "com.nomad"
 version = "0.0.1-SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_20
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {
@@ -42,7 +42,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs += "-Xjsr305=strict"
-        jvmTarget = "20"
+        jvmTarget = "17"
     }
 }
 

--- a/src/main/kotlin/com/nomad/nomad/common/exception/NotFoundEntityException.kt
+++ b/src/main/kotlin/com/nomad/nomad/common/exception/NotFoundEntityException.kt
@@ -1,0 +1,3 @@
+package com.nomad.nomad.common.exception
+
+class NotFoundEntityException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/nomad/nomad/common/exception_handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/nomad/nomad/common/exception_handler/GlobalExceptionHandler.kt
@@ -1,0 +1,14 @@
+package com.nomad.nomad.common.exception_handler
+
+import com.nomad.nomad.common.exception.NotFoundEntityException
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(NotFoundEntityException::class)
+    fun handleNotFoundEntityException(e: NotFoundEntityException): ResponseEntity<Nothing> {
+        return ResponseEntity.notFound().build()
+    }
+}

--- a/src/main/kotlin/com/nomad/nomad/region/controller/ProvinceRegionController.kt
+++ b/src/main/kotlin/com/nomad/nomad/region/controller/ProvinceRegionController.kt
@@ -1,9 +1,11 @@
 package com.nomad.nomad.region.controller
 
 import com.nomad.nomad.region.dto.RegionIndexResponse
+import com.nomad.nomad.region.dto.RegionShowResponse
 import com.nomad.nomad.region.service.ProvinceRegionService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,4 +16,9 @@ class ProvinceRegionController(
 ) {
     @GetMapping
     fun index(): ResponseEntity<List<RegionIndexResponse>> = ResponseEntity.ok(provinceRegionService.findAll())
+
+    @GetMapping("/{id}")
+    fun show(@PathVariable id: Long): ResponseEntity<RegionShowResponse> = ResponseEntity.ok(
+        provinceRegionService.findById(id),
+    )
 }

--- a/src/main/kotlin/com/nomad/nomad/region/dto/RegionIndexResponse.kt
+++ b/src/main/kotlin/com/nomad/nomad/region/dto/RegionIndexResponse.kt
@@ -1,7 +1,7 @@
 package com.nomad.nomad.region.dto
 
 data class RegionIndexResponse(
-    val id: Long,
-    val name: String,
-    val thumbnailImage: String,
+    val id: Long?,
+    val name: String?,
+    val thumbnailImage: String?,
 )

--- a/src/main/kotlin/com/nomad/nomad/region/dto/RegionShowResponse.kt
+++ b/src/main/kotlin/com/nomad/nomad/region/dto/RegionShowResponse.kt
@@ -1,0 +1,8 @@
+package com.nomad.nomad.region.dto
+
+data class RegionShowResponse(
+    val id: Long?,
+    val name: String?,
+    val description: String?,
+    val mainImage: String?,
+)

--- a/src/main/kotlin/com/nomad/nomad/region/service/ProvinceRegionService.kt
+++ b/src/main/kotlin/com/nomad/nomad/region/service/ProvinceRegionService.kt
@@ -1,6 +1,8 @@
 package com.nomad.nomad.region.service
 
+import com.nomad.nomad.common.exception.NotFoundEntityException
 import com.nomad.nomad.region.dto.RegionIndexResponse
+import com.nomad.nomad.region.dto.RegionShowResponse
 import com.nomad.nomad.region.repository.ProvinceRegionRepository
 import org.springframework.stereotype.Service
 
@@ -10,7 +12,18 @@ class ProvinceRegionService(
 ) {
     fun findAll(): List<RegionIndexResponse> {
         return provinceRegionRepository.findAll()
-            .map { RegionIndexResponse(it.id!!, it.name!!, it.thumbnailImage!!) }
+            .map { RegionIndexResponse(it.id, it.name, it.thumbnailImage) }
             .toList()
+    }
+
+    fun findById(id: Long): RegionShowResponse {
+        val provinceRegion = provinceRegionRepository.findById(id)
+            .orElseThrow { NotFoundEntityException("해당 지역을 찾을 수 없습니다.") }
+        return RegionShowResponse(
+            provinceRegion.id,
+            provinceRegion.name,
+            provinceRegion.description,
+            provinceRegion.mainImage,
+        )
     }
 }


### PR DESCRIPTION
## 배경
- 지역 상세 페이지에 지역 정보를 보여줘야 한다.

## 작업
- 지역 상세 페이지 API를 구현함.
- GET api/v1/regions/{id}
  - response body
  ````
     {
        id: number, // 지역 ID
        name: String. // 지역 이름
        description: String, // 지역 설명
        mainImage: String // 지역 메인 사진
     } 
  ````

## 기타사항
- 아직 API 문서를 작성하지 않음.
- 테스트 코드를 작성하지 않음.